### PR TITLE
Change a couple ports to direct traffic properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN cp /etc/ibcontroller/edemo.ini /etc/ibcontroller/conf.ini
 COPY start.sh /start.sh
 RUN chmod a+x /start.sh
 
-EXPOSE 4001
+EXPOSE 4003
 
 CMD ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -20,7 +20,7 @@ for VAR in `env`; do
     fi
 done
 
-socat TCP-LISTEN:4003,fork TCP:127.0.0.1:4001&
+socat TCP-LISTEN:4003,fork TCP:127.0.0.1:4002&
 
 /usr/sbin/xvfb-run \
     --auto-servernum \


### PR DESCRIPTION
Per comments on [Docker Hub](https://hub.docker.com/r/ibizaman/docker-ibcontroller/), these changes EXPOSE 4003 so that docker will pass port 4003 traffic to the container, then socat will redirect it to 4001 (the port IB Controller listens on).  

Note that even when built, the resulting image requires a ibg.xml file to be added from it. 